### PR TITLE
fead: User CRUD, JWT, Security 설정 구현 

### DIFF
--- a/src/main/java/sparta/jeogiyo/JeogiyoApplication.java
+++ b/src/main/java/sparta/jeogiyo/JeogiyoApplication.java
@@ -1,6 +1,5 @@
 package sparta.jeogiyo;
 
-import jakarta.persistence.Entity;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/sparta/jeogiyo/domain/user/UserDetailsImpl.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/UserDetailsImpl.java
@@ -1,24 +1,39 @@
 package sparta.jeogiyo.domain.user;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import sparta.jeogiyo.domain.user.entity.User;
 
 public class UserDetailsImpl implements UserDetails {
 
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return user.getRoles().stream()
+                .map(role -> new SimpleGrantedAuthority(role.getRoleName()))
+                .collect(Collectors.toList());
     }
 
     @Override
     public String getPassword() {
-        return "";
+        return user.getPassword();
     }
 
     @Override
     public String getUsername() {
-        return "";
+        return user.getUsername();
     }
+
+    public User getUser() {
+        return user;
+    }
+
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/UserDetailsServiceImpl.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/UserDetailsServiceImpl.java
@@ -3,11 +3,28 @@ package sparta.jeogiyo.domain.user;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.jeogiyo.domain.user.entity.User;
+import sparta.jeogiyo.domain.user.repository.UserRepository;
+import sparta.jeogiyo.global.response.ErrorCode;
 
+@Service
 public class UserDetailsServiceImpl implements UserDetailsService {
 
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return null;
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(
+                        () -> new UsernameNotFoundException(ErrorCode.USER_NOT_FOUND.getMessage()));
+        return new UserDetailsImpl(user);
+    }
+
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/controller/UserController.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/controller/UserController.java
@@ -1,8 +1,79 @@
 package sparta.jeogiyo.domain.user.controller;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import sparta.jeogiyo.domain.user.dto.request.UserDeleteRequestDto;
+import sparta.jeogiyo.domain.user.dto.request.UserSignUpRequestDto;
+import sparta.jeogiyo.domain.user.dto.request.UserUpdateRequestDto;
+import sparta.jeogiyo.domain.user.dto.response.UserResponseDto;
+import sparta.jeogiyo.domain.user.entity.User;
+import sparta.jeogiyo.domain.user.service.AuthService;
+import sparta.jeogiyo.domain.user.service.UserService;
+import sparta.jeogiyo.global.response.ApiResponse;
 
 @RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final AuthService authService;
+
+    private final UserService userService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<ApiResponse<Object>> signUp(
+            @RequestBody @Valid UserSignUpRequestDto requestDto) {
+        UserResponseDto userResponseDto = authService.signUp(requestDto);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of("회원가입을 성공하였습니다.", userResponseDto));
+    }
+
+    @PutMapping("/{userId}")
+    public ResponseEntity<ApiResponse<Object>> updateUser(@PathVariable Long userId,
+            @Valid @RequestBody UserUpdateRequestDto updateRequest) {
+        UserResponseDto userResponseDto = userService.updateUser(userId, updateRequest);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of("수정되었습니다.", userResponseDto));
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserResponseDto> getUserById(@PathVariable Long userId) {
+        UserResponseDto user = userService.getUserById(userId);
+        return ResponseEntity.ok(user);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Object>> getAllUsers(
+            @RequestParam("page") int page,
+            @RequestParam("size") int size,
+            @RequestParam("sortBy") String sortBy,
+            @RequestParam("isAsc") boolean isAsc
+    ) {
+        Page<User> pageUser = userService.getAllUsers(page, size, sortBy, isAsc);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.of("회원 전체 목록", pageUser));
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<String> deleteUser(@PathVariable Long userId,
+            @Valid @RequestBody UserDeleteRequestDto deleteRequestDto) {
+        userService.deleteUser(userId, deleteRequestDto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserDeleteRequestDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserDeleteRequestDto.java
@@ -1,0 +1,19 @@
+package sparta.jeogiyo.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UserDeleteRequestDto {
+
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Size(min = 8, max = 15, message = "비밀번호는 최소 8자, 최대 15자 이어야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+            message = "비밀번호는 하나 이상의 대문자, 소문자, 숫자, 특수 문자를 포함해야 합니다."
+    )
+    private String password;
+
+}

--- a/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserSignInRequestDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserSignInRequestDto.java
@@ -1,8 +1,24 @@
 package sparta.jeogiyo.domain.user.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class UserSignInRequestDto {
+
+    @NotBlank(message = "아이디는 필수 항목입니다.")
+    @Size(min = 4, max = 10, message = "아이디는 최소 4자, 최대 10자 이어야 합니다.")
+    @Pattern(regexp = "^[a-z0-9]+$", message = "아이디는 소문자와 숫자 조합만 가능합니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Size(min = 8, max = 15, message = "비밀번호는 최소 8자, 최대 15자 이어야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+            message = "비밀번호는 하나 이상의 대문자, 소문자, 숫자, 특수 문자를 포함해야 합니다."
+    )
+    private String password;
 
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserSignUpRequestDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserSignUpRequestDto.java
@@ -5,10 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import sparta.jeogiyo.domain.user.entity.User;
 import sparta.jeogiyo.domain.user.entity.UserRoleEnum;
 
 @Getter
@@ -41,10 +39,16 @@ public class UserSignUpRequestDto {
 
     private Boolean isPublic = true;
 
-    public List<GrantedAuthority> getAuthorities() {
-        return roles.stream()
-                .map(role -> new SimpleGrantedAuthority(role.getRoleName()))
-                .collect(Collectors.toList());
+    public User toUser(String encodedPassword) {
+        return User.builder()
+                .username(username)
+                .nickname(nickname)
+                .password(encodedPassword)
+                .email(email)
+                .address(address)
+                .roles(roles)
+                .isPublic(isPublic)
+                .build();
     }
 
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserSignUpRequestDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserSignUpRequestDto.java
@@ -1,8 +1,50 @@
 package sparta.jeogiyo.domain.user.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import sparta.jeogiyo.domain.user.entity.UserRoleEnum;
 
 @Getter
 public class UserSignUpRequestDto {
+
+    @NotBlank(message = "아이디는 필수 항목입니다.")
+    @Size(min = 4, max = 10, message = "아이디는 최소 4자, 최대 10자 이어야 합니다.")
+    @Pattern(regexp = "^[a-z0-9]+$", message = "아이디는 소문자와 숫자 조합만 가능합니다.")
+    private String username;
+
+    @Email(message = "올바르지 않은 이메일 형식입니다.")
+    private String email;
+
+    @NotBlank(message = "닉네임은 필수 항목입니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,8}$", message = "닉네임은 특수문자를 제외한 2글자에서 8글자 사이여야 합니다.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Size(min = 8, max = 15, message = "비밀번호는 최소 8자, 최대 15자 이어야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+            message = "비밀번호는 하나 이상의 대문자, 소문자, 숫자, 특수 문자를 포함해야 합니다."
+    )
+    private String password;
+
+    @NotBlank(message = "주소는 필수 항목입니다.")
+    private String address;
+
+    private List<UserRoleEnum> roles = List.of(UserRoleEnum.CUSTOMER);
+
+    private Boolean isPublic = true;
+
+    public List<GrantedAuthority> getAuthorities() {
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority(role.getRoleName()))
+                .collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserUpdateRequestDto.java
@@ -1,8 +1,37 @@
 package sparta.jeogiyo.domain.user.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class UserUpdateRequestDto {
+
+    @NotBlank(message = "닉네임은 필수 항목입니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,8}$", message = "닉네임은 특수문자를 제외한 2글자에서 8글자 사이여야 합니다.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호는 필수 항목입니다.")
+    @Size(min = 8, max = 15, message = "비밀번호는 최소 8자, 최대 15자 이어야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+            message = "비밀번호는 하나 이상의 대문자, 소문자, 숫자, 특수 문자를 포함해야 합니다."
+    )
+    private String currentPassword;
+
+    @Size(min = 8, max = 15, message = "비밀번호는 최소 8자, 최대 15자 이어야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]+$",
+            message = "비밀번호는 하나 이상의 대문자, 소문자, 숫자, 특수 문자를 포함해야 합니다."
+    )
+    private String updatePassword;
+
+    @NotBlank(message = "주소는 필수 항목입니다.")
+    private String address;
+
+    public void setPassword (String password) {
+        this.updatePassword = password;
+    }
 
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/dto/request/UserUpdateRequestDto.java
@@ -30,7 +30,7 @@ public class UserUpdateRequestDto {
     @NotBlank(message = "주소는 필수 항목입니다.")
     private String address;
 
-    public void setPassword (String password) {
+    public void setUpdatePassword(String password) {
         this.updatePassword = password;
     }
 

--- a/src/main/java/sparta/jeogiyo/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/dto/response/UserResponseDto.java
@@ -1,8 +1,33 @@
 package sparta.jeogiyo.domain.user.dto.response;
 
+import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
+import sparta.jeogiyo.domain.user.entity.User;
+import sparta.jeogiyo.domain.user.entity.UserRoleEnum;
 
 @Getter
+@Builder
 public class UserResponseDto {
+
+    private String username;
+
+    private String nickname;
+
+    private String email;
+
+    private String address;
+
+    private List<UserRoleEnum> roles;
+
+    public static UserResponseDto fromEntity(User user) {
+        return UserResponseDto.builder()
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .address(user.getAddress())
+                .roles(user.getRoles())
+                .build();
+    }
 
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/entity/User.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/entity/User.java
@@ -1,7 +1,76 @@
 package sparta.jeogiyo.domain.user.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import sparta.jeogiyo.domain.user.dto.request.UserUpdateRequestDto;
 import sparta.jeogiyo.global.entity.BaseTimeEntity;
 
+@Entity
+@Table(name = "p_user")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long user_id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(name = "is_public")
+    private boolean isPublic;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    private List<UserRoleEnum> roles;
+
+    public void update(UserUpdateRequestDto updateRequestDto) {
+        this.nickname = updateRequestDto.getNickname();
+        this.password = updateRequestDto.getUpdatePassword();
+        this.address = updateRequestDto.getAddress();
+    }
+
+    public void delete() {
+        this.isPublic = false;
+        this.isDeleted = true;
+        this.setDeletedAt(LocalDateTime.now());
+        this.setDeletedBy(this.username);
+    }
 
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/entity/UserRoleEnum.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/entity/UserRoleEnum.java
@@ -1,0 +1,18 @@
+package sparta.jeogiyo.domain.user.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRoleEnum {
+
+    CUSTOMER("CUSTOMER"),
+    OWNER("OWNER"),
+    MASTER("MASTER");
+
+    private final String roleName;
+
+    UserRoleEnum(String roleName) {
+        this.roleName = roleName;
+    }
+
+}

--- a/src/main/java/sparta/jeogiyo/domain/user/repository/UserRepository.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/repository/UserRepository.java
@@ -1,10 +1,17 @@
 package sparta.jeogiyo.domain.user.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import sparta.jeogiyo.domain.user.entity.User;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByNickname(String nickname);
 
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/service/AuthService.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/service/AuthService.java
@@ -1,0 +1,68 @@
+package sparta.jeogiyo.domain.user.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.jeogiyo.domain.user.dto.request.UserSignUpRequestDto;
+import sparta.jeogiyo.domain.user.dto.response.UserResponseDto;
+import sparta.jeogiyo.domain.user.entity.User;
+import sparta.jeogiyo.domain.user.repository.UserRepository;
+import sparta.jeogiyo.global.response.CustomException;
+import sparta.jeogiyo.global.response.ErrorCode;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserResponseDto signUp(UserSignUpRequestDto requestDto) {
+        String username = requestDto.getUsername();
+        String password = passwordEncoder.encode(requestDto.getPassword());
+
+        validateUserSignUp(requestDto);
+
+        User user = User.builder()
+                .username(username)
+                .nickname(requestDto.getNickname())
+                .password(password)
+                .email(requestDto.getEmail())
+                .address(requestDto.getAddress())
+                .roles(requestDto.getRoles())
+                .isPublic(true)
+                .build();
+        userRepository.save(user);
+        log.info("회원가입 성공: username={}, email={}", username, requestDto.getEmail());
+        return UserResponseDto.fromEntity(user);
+    }
+
+    private final PasswordEncoder passwordEncoder;
+
+    private void validateUserSignUp(UserSignUpRequestDto requestDto) {
+        Optional<User> checkUsername = userRepository.findByUsername(requestDto.getUsername());
+        if (checkUsername.isPresent()) {
+            log.warn("회원가입 실패 - 중복된 아이디: {}", requestDto.getUsername());
+            throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
+        }
+
+        String email = requestDto.getEmail();
+        Optional<User> checkEmail = userRepository.findByEmail(email);
+        if (checkEmail.isPresent()) {
+            log.warn("회원가입 실패 - 중복된 이메일: {}", email);
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        String nickname = requestDto.getNickname();
+        Optional<User> checkNickname = userRepository.findByNickname(nickname);
+        if (checkNickname.isPresent()) {
+            log.warn("회원가입 실패 - 중복된 닉네임: {}", nickname);
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
+
+}

--- a/src/main/java/sparta/jeogiyo/domain/user/service/AuthService.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/service/AuthService.java
@@ -27,16 +27,10 @@ public class AuthService {
 
         validateUserSignUp(requestDto);
 
-        User user = User.builder()
-                .username(username)
-                .nickname(requestDto.getNickname())
-                .password(password)
-                .email(requestDto.getEmail())
-                .address(requestDto.getAddress())
-                .roles(requestDto.getRoles())
-                .isPublic(true)
-                .build();
+        User user = requestDto.toUser(password);
+        user.setCreatedBy(username);
         userRepository.save(user);
+
         log.info("회원가입 성공: username={}, email={}", username, requestDto.getEmail());
         return UserResponseDto.fromEntity(user);
     }

--- a/src/main/java/sparta/jeogiyo/domain/user/service/UserService.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/service/UserService.java
@@ -1,8 +1,110 @@
 package sparta.jeogiyo.domain.user.service;
 
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.jeogiyo.domain.user.UserDetailsImpl;
+import sparta.jeogiyo.domain.user.dto.request.UserDeleteRequestDto;
+import sparta.jeogiyo.domain.user.dto.request.UserUpdateRequestDto;
+import sparta.jeogiyo.domain.user.dto.response.UserResponseDto;
+import sparta.jeogiyo.domain.user.entity.User;
+import sparta.jeogiyo.domain.user.repository.UserRepository;
+import sparta.jeogiyo.global.response.CustomException;
+import sparta.jeogiyo.global.response.ErrorCode;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
+    private final UserRepository userRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional(readOnly = true)
+    public UserResponseDto getUserById(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(
+                ErrorCode.USER_NOT_FOUND));
+        if (user.isDeleted() || !user.isPublic()) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        return UserResponseDto.fromEntity(user);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<User> getAllUsers(int page, int size, String sortBy, boolean isAsc) {
+        if (size != 10 && size != 30 && size != 50) {
+            size = 10;
+        }
+
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        return userRepository.findAll(pageable);
+    }
+
+    @Transactional
+    public UserResponseDto updateUser(Long updateUserId, UserUpdateRequestDto updateRequestDto) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) SecurityContextHolder.getContext()
+                .getAuthentication().getPrincipal();
+        User user = userDetails.getUser();
+
+        validateUserRequestDto(user, updateUserId, updateRequestDto.getCurrentPassword());
+
+        if (updateRequestDto.getUpdatePassword() == null || updateRequestDto.getUpdatePassword()
+                .isBlank()) {
+            String encodedUpdatePassword = passwordEncoder.encode(
+                    updateRequestDto.getUpdatePassword());
+            updateRequestDto.setPassword(encodedUpdatePassword);
+        } else {
+            updateRequestDto.setPassword(user.getPassword());
+        }
+
+        user.update(updateRequestDto);
+        userRepository.save(user);
+        return UserResponseDto.fromEntity(user);
+    }
+
+    @Transactional
+    public void deleteUser(Long deleteUserId, UserDeleteRequestDto deleteRequestDto) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) SecurityContextHolder.getContext()
+                .getAuthentication().getPrincipal();
+        User user = userDetails.getUser();
+
+        validateUserRequestDto(user, deleteUserId, deleteRequestDto.getPassword());
+
+        user.delete();
+        user.setDeletedAt(LocalDateTime.now());
+        user.setDeletedBy(user.getUsername());
+        userRepository.save(user);
+    }
+
+    public void validateUserRequestDto(User user, Long requestId, String requestUserPassword) {
+        // 이미 soft 삭제된 User인 경우
+        if (user.isDeleted()) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        // 토큰으로 인증된 User Id와 요청하는 User의 Id와 다른 경우
+        if (!Objects.equals(requestId, user.getUser_id())) {
+            throw new CustomException(ErrorCode.USER_UNAUTHORIZED);
+        }
+
+        // User의 비밀번호가 요청하는 User의 비밀번호와 다른 경우
+        if (!passwordEncoder.matches(requestUserPassword, user.getPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_NOT_MATCH);
+        }
+    }
 }

--- a/src/main/java/sparta/jeogiyo/domain/user/service/UserService.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/service/UserService.java
@@ -7,10 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,13 +60,12 @@ public class UserService {
 
         validateUserRequestDto(user, updateUserId, updateRequestDto.getCurrentPassword());
 
-        if (updateRequestDto.getUpdatePassword() == null || updateRequestDto.getUpdatePassword()
-                .isBlank()) {
+        if (updateRequestDto.getUpdatePassword() == null) {
+            updateRequestDto.setUpdatePassword(user.getPassword());
+        } else {
             String encodedUpdatePassword = passwordEncoder.encode(
                     updateRequestDto.getUpdatePassword());
-            updateRequestDto.setPassword(encodedUpdatePassword);
-        } else {
-            updateRequestDto.setPassword(user.getPassword());
+            updateRequestDto.setUpdatePassword(encodedUpdatePassword);
         }
 
         user.update(updateRequestDto);

--- a/src/main/java/sparta/jeogiyo/global/entity/BaseTimeEntity.java
+++ b/src/main/java/sparta/jeogiyo/global/entity/BaseTimeEntity.java
@@ -5,7 +5,9 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -21,6 +23,22 @@ public abstract class BaseTimeEntity {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private String createdBy;
+
     @LastModifiedDate
-    private LocalDateTime modifiedAt;
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private String deletedBy;
+
 }

--- a/src/main/java/sparta/jeogiyo/global/entity/CustomAuditorAware.java
+++ b/src/main/java/sparta/jeogiyo/global/entity/CustomAuditorAware.java
@@ -1,0 +1,20 @@
+package sparta.jeogiyo.global.entity;
+
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import sparta.jeogiyo.domain.user.UserDetailsImpl;
+
+@Component
+public class CustomAuditorAware implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal instanceof UserDetailsImpl userDetails) {
+            return Optional.of(userDetails.getUsername());
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/sparta/jeogiyo/global/entity/CustomAuditorAware.java
+++ b/src/main/java/sparta/jeogiyo/global/entity/CustomAuditorAware.java
@@ -6,6 +6,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import sparta.jeogiyo.domain.user.UserDetailsImpl;
 
+/**
+ * BaseTimeEntity 클래스에서  @CreatedBy와  @LastModifiedBy를
+ * 자동으로 감지하기 위해 사용되는 클래스입니다.
+ */
 @Component
 public class CustomAuditorAware implements AuditorAware<String> {
 

--- a/src/main/java/sparta/jeogiyo/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/sparta/jeogiyo/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,93 @@
+package sparta.jeogiyo.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import sparta.jeogiyo.domain.user.UserDetailsImpl;
+import sparta.jeogiyo.domain.user.dto.request.UserSignInRequestDto;
+import sparta.jeogiyo.domain.user.dto.response.UserResponseDto;
+import sparta.jeogiyo.domain.user.entity.User;
+import sparta.jeogiyo.global.response.ApiResponse;
+import sparta.jeogiyo.global.response.ErrorCode;
+import sparta.jeogiyo.global.response.ResponseMapper;
+
+@Slf4j
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final JwtUtil jwtUtil;
+
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+        setFilterProcessesUrl("/api/users/sign-in");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+            HttpServletResponse response) throws AuthenticationException {
+
+        UserSignInRequestDto requestDto = null;
+        try {
+            requestDto = new ObjectMapper().readValue(request.getInputStream(),
+                    UserSignInRequestDto.class);
+        } catch (IOException e) {
+            throw new UsernameNotFoundException(ErrorCode.INVALID_REQUEST_BODY.getMessage());
+        }
+
+        log.info("사용자 로그인 시도: 아이디 {}", requestDto.getUsername());
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(requestDto.getUsername());
+        return getAuthenticationManager().authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        requestDto.getPassword(),
+                        userDetails.getAuthorities()
+                )
+        );
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+            HttpServletResponse response, FilterChain chain, Authentication authResult)
+            throws IOException, ServletException {
+        User user = ((UserDetailsImpl) authResult.getPrincipal()).getUser();
+        String token = jwtUtil.createToken(user.getUsername(), user.getRoles());
+        response.addHeader("Authorization", token);
+
+        String jsonResponse = new ObjectMapper().writeValueAsString(
+                ApiResponse.of("로그인에 성공하였습니다.", UserResponseDto.fromEntity(user)));
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(jsonResponse);
+
+//        jwtUtil.addJwtToCookie(token, response);
+
+        log.info("사용자 로그인 성공: 아이디 {}, 권한 {}", user.getUsername(), user.getRoles());
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request,
+            HttpServletResponse response, AuthenticationException failed)
+            throws IOException, ServletException {
+        log.warn("사용자 로그인 실패: {}", failed.getMessage());
+        if (failed.getMessage().equals(ErrorCode.INVALID_REQUEST_BODY.getMessage())) {
+            ResponseMapper.writeErrorCodeResponse(response, ErrorCode.INVALID_REQUEST_BODY);
+        } else {
+            ResponseMapper.writeErrorCodeResponse(response, ErrorCode.INVALID_USERNAME_PASSWORD);
+        }
+    }
+}

--- a/src/main/java/sparta/jeogiyo/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/sparta/jeogiyo/global/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,67 @@
+package sparta.jeogiyo.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.filter.OncePerRequestFilter;
+import sparta.jeogiyo.global.response.ErrorCode;
+import sparta.jeogiyo.global.response.ResponseMapper;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            String token = jwtUtil.getJwtFromHeader(request);
+//            if (token.isBlank()) {
+//                token = jwtUtil.getJwtFromCookie(request);
+//            }
+            if (!token.isBlank()) {
+                if (!jwtUtil.validateToken(token)) {
+                    log.error("JWT 토큰 검증 실패: {}", token);
+                    ResponseMapper.writeErrorCodeResponse(response, ErrorCode.INVALID_JWT_TOKEN);
+                    return;
+                }
+
+                Claims info = jwtUtil.getUserInfoFromToken(token);
+
+                try {
+                    setAuthentication(info.getSubject());
+                } catch (UsernameNotFoundException e) {
+                    ResponseMapper.writeErrorCodeResponse(response, ErrorCode.USER_NOT_FOUND);
+                    return;
+                }
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthentication(String username) {
+        try {
+            UserDetails user = userDetailsService.loadUserByUsername(username);
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    user, user.getPassword(), user.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (UsernameNotFoundException e) {
+            throw new UsernameNotFoundException(ErrorCode.USER_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/main/java/sparta/jeogiyo/global/jwt/JwtUtil.java
+++ b/src/main/java/sparta/jeogiyo/global/jwt/JwtUtil.java
@@ -1,0 +1,112 @@
+package sparta.jeogiyo.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import sparta.jeogiyo.domain.user.entity.UserRoleEnum;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+
+    public final String AUTHORIZATION_HEADER = "Authorization";
+
+    public final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${jwt.secret.expiration-time}")
+    private long EXPIRATION_TIME;
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    private Key key;
+
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(String username, List<UserRoleEnum> roles) {
+        Date date = new Date();
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("roles", roles);
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setClaims(claims)
+                        .setSubject(username)
+                        .setExpiration(new Date(date.getTime() + EXPIRATION_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    public void addJwtToCookie(String token, HttpServletResponse res) {
+        token = URLEncoder.encode(token, StandardCharsets.UTF_8);
+
+        Cookie jwtCookie = new Cookie(AUTHORIZATION_HEADER, token);
+        jwtCookie.setHttpOnly(true);
+        jwtCookie.setPath("/");
+        jwtCookie.setMaxAge((int) EXPIRATION_TIME / 1000);
+
+        res.addCookie(jwtCookie);
+    }
+
+    public String getJwtFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken)) {
+            String decodedToken = URLDecoder.decode(bearerToken, StandardCharsets.UTF_8);
+            if (decodedToken.startsWith(BEARER_PREFIX)) {
+                return decodedToken.substring(7);
+            }
+        }
+        return "";
+    }
+
+    public String getJwtFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (AUTHORIZATION_HEADER.equals(cookie.getName())) {
+                String decodedToken = URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8);
+                if (decodedToken.startsWith(BEARER_PREFIX)) {
+                    return decodedToken.substring(7);
+                }
+            }
+        }
+        return "";
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+}

--- a/src/main/java/sparta/jeogiyo/global/response/ApiResponse.java
+++ b/src/main/java/sparta/jeogiyo/global/response/ApiResponse.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ApiResponse<T>{
+public class ApiResponse<T> {
 
     private String message;
     private T data;

--- a/src/main/java/sparta/jeogiyo/global/response/ErrorCode.java
+++ b/src/main/java/sparta/jeogiyo/global/response/ErrorCode.java
@@ -12,7 +12,21 @@ public enum ErrorCode {
     BAD_REQUEST(400, "Bad request."),
     UNAUTHORIZED(401, "Unauthorized access."),
     FORBIDDEN(403, "Forbidden."),
-    INTERNAL_SERVER_ERROR(500, "Internal server error.");
+    INTERNAL_SERVER_ERROR(500, "Internal server error."),
+    INVALID_REQUEST_BODY(400, "잘못된 요청 입니다."),
+
+    // User 관련
+    DUPLICATE_EMAIL(409, "중복된 이메일입니다."),
+    DUPLICATE_USERNAME(409, "중복된 아이디입니다."),
+    DUPLICATE_NICKNAME(409, "중복된 닉네임입니다."),
+    USER_NOT_FOUND(404, "존재하지 않는 사용자입니다."),
+    INVALID_USERNAME_PASSWORD(401, "아이디 또는 비밀번호가 틀렸습니다."),
+    PASSWORD_NOT_MATCH(401, "비밀번호가 틀렸습니다."),
+    USER_UNAUTHORIZED(401, "권한이 없는 사용자입니다."),
+
+    // JWT 관련
+    INVALID_JWT_TOKEN(401, "유효하지 않은 토큰입니다."),
+    UNSUPPORTED_JWT_TOKEN(401, "지원되지 않는 JWT 토큰입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/sparta/jeogiyo/global/response/ResponseMapper.java
+++ b/src/main/java/sparta/jeogiyo/global/response/ResponseMapper.java
@@ -1,0 +1,23 @@
+package sparta.jeogiyo.global.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ResponseMapper {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static void writeErrorCodeResponse(HttpServletResponse response, ErrorCode errorCode)
+            throws IOException {
+        response.setStatus(errorCode.getStatus());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String jsonResponse = objectMapper.writeValueAsString(
+                ApiResponse.of(errorCode.getMessage(), null));
+
+        response.getWriter().write(jsonResponse);
+    }
+
+}

--- a/src/main/java/sparta/jeogiyo/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/sparta/jeogiyo/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package sparta.jeogiyo.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import sparta.jeogiyo.global.response.ErrorCode;
+import sparta.jeogiyo.global.response.ResponseMapper;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ResponseMapper.writeErrorCodeResponse(response, ErrorCode.USER_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/sparta/jeogiyo/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/sparta/jeogiyo/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package sparta.jeogiyo.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import sparta.jeogiyo.global.response.ErrorCode;
+import sparta.jeogiyo.global.response.ResponseMapper;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
+        ResponseMapper.writeErrorCodeResponse(response, ErrorCode.INVALID_JWT_TOKEN);
+    }
+}

--- a/src/main/java/sparta/jeogiyo/global/security/WebSecurityConfig.java
+++ b/src/main/java/sparta/jeogiyo/global/security/WebSecurityConfig.java
@@ -1,0 +1,175 @@
+package sparta.jeogiyo.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import sparta.jeogiyo.domain.user.entity.UserRoleEnum;
+import sparta.jeogiyo.global.jwt.JwtAuthenticationFilter;
+import sparta.jeogiyo.global.jwt.JwtAuthorizationFilter;
+import sparta.jeogiyo.global.jwt.JwtUtil;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    private final JwtUtil jwtUtil;
+
+    private final UserDetailsService userDetailsService;
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+            throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        final String MASTER = UserRoleEnum.MASTER.getRoleName();
+        final String CUSTOMER = UserRoleEnum.CUSTOMER.getRoleName();
+        final String OWNER = UserRoleEnum.OWNER.getRoleName();
+
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+
+                        // 유저 관련
+                        // 로그인, 회원가입
+                        .requestMatchers(HttpMethod.POST, "/api/users/sign-up",
+                                "/api/users/sign-in").permitAll()
+
+                        // 유저 전체 조회
+                        .requestMatchers(HttpMethod.GET, "/api/users").hasAuthority(MASTER)
+
+                        // 유저 정보 수정
+                        .requestMatchers(HttpMethod.PUT, "/api/users/**").permitAll()
+
+                        // 유저 삭제
+                        .requestMatchers(HttpMethod.DELETE, "/api/users/**").permitAll()
+
+                        // 유저 단일 조회
+                        .requestMatchers(HttpMethod.GET, "/api/users/**").permitAll()
+
+                        // 가게 관련
+                        // 가게 등록
+                        .requestMatchers(HttpMethod.POST, "/api/stores").hasAnyRole(OWNER, MASTER)
+
+                        // 가게 수정
+                        .requestMatchers(HttpMethod.PATCH, "/api/stores/**")
+                        .hasAnyRole(OWNER, MASTER)
+
+                        // 가게 단일 조회
+                        .requestMatchers(HttpMethod.GET, "/api/stores/**").permitAll()
+
+                        // 가게 전체 조회
+                        .requestMatchers(HttpMethod.GET, "/api/stores").permitAll()
+
+                        // 주문 관련
+                        // 주문 등록
+                        .requestMatchers(HttpMethod.POST, "/api/orders/cart/**")
+                        .hasAnyRole(CUSTOMER, MASTER)
+
+                        // 주문 수정
+                        .requestMatchers(HttpMethod.PATCH, "/api/stores/**")
+                        .hasAnyRole(OWNER, MASTER)
+
+                        // 주문 삭제
+                        .requestMatchers(HttpMethod.DELETE, "/api/orders/**").permitAll()
+
+                        // 주문 상세 조회
+                        .requestMatchers(HttpMethod.GET, "/api/orders/**").permitAll()
+
+                        // 결제 관련
+                        // 결제 요청
+                        .requestMatchers(HttpMethod.POST, "/api/payments/order/**").permitAll()
+
+                        // 결제(주문) 취소
+                        .requestMatchers(HttpMethod.POST, "/api/payments/order/{orderId}/cancel")
+                        .permitAll()
+
+                        // 결제 내역 상세 조회
+                        .requestMatchers(HttpMethod.GET, "/api/payments/**").permitAll()
+
+                        // 결제 내역 전체 조회
+                        .requestMatchers(HttpMethod.GET, "/api/payments").permitAll()
+
+                        // 상품 관련
+                        // 상품 생성
+                        .requestMatchers(HttpMethod.POST, "/api/products/store/**").hasRole(OWNER)
+
+                        // 상품 수정
+                        .requestMatchers(HttpMethod.PATCH, "/api/products/**").hasRole(OWNER)
+
+                        // 상품 삭제
+                        .requestMatchers(HttpMethod.DELETE, "/api/products/**")
+                        .hasAnyRole(OWNER, MASTER)
+
+                        // 상품 단일 조회
+                        .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
+
+                        // 상품 전체 조회
+                        .requestMatchers(HttpMethod.GET, "/api/products").permitAll()
+
+                        // 장바구니 관련
+                        // 장바구니 메뉴 담기
+                        .requestMatchers(HttpMethod.POST, "/api/carts/product/**")
+                        .hasAnyRole(CUSTOMER, MASTER)
+
+                        // 장바구니 메뉴 삭제
+                        .requestMatchers(HttpMethod.DELETE, "/api/carts/product/**")
+                        .hasAnyRole(CUSTOMER, MASTER)
+
+                        // 장바구니 조회
+                        .requestMatchers(HttpMethod.GET, "/api/carts").hasAnyRole(CUSTOMER, MASTER)
+
+                        // Chatbot 관련
+                        .requestMatchers(HttpMethod.POST, "/api/chats").hasAnyRole(OWNER, MASTER));
+
+        http.sessionManagement(
+                session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.addFilterBefore(createJwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+        http.addFilterBefore(createJwtAuthenticationFilter(),
+                UsernamePasswordAuthenticationFilter.class);
+
+        http.exceptionHandling((exceptionHandling) ->
+                exceptionHandling.authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler));
+
+        return http.build();
+    }
+
+    public JwtAuthenticationFilter createJwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, userDetailsService);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return filter;
+    }
+
+    public JwtAuthorizationFilter createJwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,3 +12,8 @@ spring:
       hibernate:
         show_sql: true
     open-in-view: false
+
+jwt:
+  secret:
+    expiration-time: 60 * 60 * 1000L
+    key: a12f3b4e5c6d7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8a9b0c1d2e3f


### PR DESCRIPTION
### 구현 내용 

## User 관련

- username이 로그인할 때 필요한 아이디입니다.
- Role은 MASTER, CUSTOMER, OWNER가 있습니다.
- Role과 Authority는 구분 짓지 않고 같게 생각해서 구현했습니다.
- Update와 Delete는 **본인의 토큰으로만** 가능하도록 구현했습니다.
- Update, Delete는 현재 본인의 비밀번호를 body에 포함시켜야 합니다.
- Update의 경우, updatePassword는 null일 수 있습니다.

## JWT 관련

- JwtAuthenticationFilter: **로그인** 관련 기능을 수행합니다.
- JwtAuthorizationFilter: 요청마다 토큰 검증 후 SecurityContext를 저장합니다.
- 토큰 만료 시간은 1시간으로 설정했습니다.
- refresh token은 미구현입니다.
- Cookie에 JWT를 넣는 로직은 비활성화 했습니다.(테스트를 편하게 하기 위해)

**토큰 payload 형식**
```json
  "payload": {
    "sub": "exampleUsername", // `username` 값
    "roles": ["MASTER"], // `roles` 값
    "exp": 1716239022, // `EXPIRATION_TIME`에 기반한 만료 시간
    "iat": 1716235422 // 발급 시간
  }
```

## Security 관련

- 일단 API 명세서대로 엔드포인트 별로 권한에 따라 ROLE이 필요하도록 구현하였습니다.
- **CustomAuthenticationEntryPoint**:  유효하지 않은 토큰으로 요청 시 처리할 Exception 입니다.
- **CustomAccessDeniedHandler**: 권한이 없는 토큰의 유저가 요청 시 처리할 Exception 입니다.
- **ResponseMapper**: Security 레벨에서는 HttpServlet 객체에 직접 context-type, body를 작성해야 해서 그 로직을 포함하였습니다.

**UsernamePasswordAuthenticationToken 형식**
```java
{
  "principal": UserDetails 객체
  "credentials": "ffaWFEIhfiaofds..", // encoding된 비밀번호
  "authorities": [
    "MASTER",
  ]
}
```

## 기타

- BaseTimeEntity에 deletedBy, deletedAt 등 필요한 필드를 추가했습니다.
- deletedBy, deletedAt 의 경우, 직접 delete할 때 설정해주어야 하는 것 같습니다.