### PR TITLE
refactor: JWT Secret key 값 환경 변수를 사용하도록 수정 + User 테이블 명 수정

### DIFF
--- a/src/main/java/sparta/jeogiyo/domain/user/entity/User.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/entity/User.java
@@ -24,7 +24,7 @@ import sparta.jeogiyo.domain.user.dto.request.UserUpdateRequestDto;
 import sparta.jeogiyo.global.entity.BaseTimeEntity;
 
 @Entity
-@Table(name = "p_user")
+@Table(name = "p_users")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,4 +16,4 @@ spring:
 jwt:
   secret:
     expiration-time: 60 * 60 * 1000L
-    key: a12f3b4e5c6d7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8a9b0c1d2e3f
+    key: ${LOCAL_JWT_SECRET_KEY}


### PR DESCRIPTION
### 수정 사항

- `p_user`로 되어있는 User 테이블 명을 ERD 명세서에 맞게 `p_users`로 수정하였습니다.
- `jwt-secret-key` 값을 환경 변수를 사용하도록 수정하였습니다.