### PR TITLE
fix: hasRole 대신 hasAuthority를 사용하도록 수정

### DIFF
--- a/src/main/java/sparta/jeogiyo/global/security/WebSecurityConfig.java
+++ b/src/main/java/sparta/jeogiyo/global/security/WebSecurityConfig.java
@@ -75,11 +75,11 @@ public class WebSecurityConfig {
 
                         // 가게 관련
                         // 가게 등록
-                        .requestMatchers(HttpMethod.POST, "/api/stores").hasAnyRole(OWNER, MASTER)
+                        .requestMatchers(HttpMethod.POST, "/api/stores").hasAnyAuthority(OWNER, MASTER)
 
                         // 가게 수정
                         .requestMatchers(HttpMethod.PATCH, "/api/stores/**")
-                        .hasAnyRole(OWNER, MASTER)
+                        .hasAnyAuthority(OWNER, MASTER)
 
                         // 가게 단일 조회
                         .requestMatchers(HttpMethod.GET, "/api/stores/**").permitAll()
@@ -90,11 +90,11 @@ public class WebSecurityConfig {
                         // 주문 관련
                         // 주문 등록
                         .requestMatchers(HttpMethod.POST, "/api/orders/cart/**")
-                        .hasAnyRole(CUSTOMER, MASTER)
+                        .hasAnyAuthority(CUSTOMER, MASTER)
 
                         // 주문 수정
                         .requestMatchers(HttpMethod.PATCH, "/api/stores/**")
-                        .hasAnyRole(OWNER, MASTER)
+                        .hasAnyAuthority(OWNER, MASTER)
 
                         // 주문 삭제
                         .requestMatchers(HttpMethod.DELETE, "/api/orders/**").permitAll()
@@ -118,14 +118,14 @@ public class WebSecurityConfig {
 
                         // 상품 관련
                         // 상품 생성
-                        .requestMatchers(HttpMethod.POST, "/api/products/store/**").hasRole(OWNER)
+                        .requestMatchers(HttpMethod.POST, "/api/products/store/**").hasAuthority(OWNER)
 
                         // 상품 수정
-                        .requestMatchers(HttpMethod.PATCH, "/api/products/**").hasRole(OWNER)
+                        .requestMatchers(HttpMethod.PATCH, "/api/products/**").hasAuthority(OWNER)
 
                         // 상품 삭제
                         .requestMatchers(HttpMethod.DELETE, "/api/products/**")
-                        .hasAnyRole(OWNER, MASTER)
+                        .hasAnyAuthority(OWNER, MASTER)
 
                         // 상품 단일 조회
                         .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
@@ -136,17 +136,17 @@ public class WebSecurityConfig {
                         // 장바구니 관련
                         // 장바구니 메뉴 담기
                         .requestMatchers(HttpMethod.POST, "/api/carts/product/**")
-                        .hasAnyRole(CUSTOMER, MASTER)
+                        .hasAnyAuthority(CUSTOMER, MASTER)
 
                         // 장바구니 메뉴 삭제
                         .requestMatchers(HttpMethod.DELETE, "/api/carts/product/**")
-                        .hasAnyRole(CUSTOMER, MASTER)
+                        .hasAnyAuthority(CUSTOMER, MASTER)
 
                         // 장바구니 조회
-                        .requestMatchers(HttpMethod.GET, "/api/carts").hasAnyRole(CUSTOMER, MASTER)
+                        .requestMatchers(HttpMethod.GET, "/api/carts").hasAnyAuthority(CUSTOMER, MASTER)
 
                         // Chatbot 관련
-                        .requestMatchers(HttpMethod.POST, "/api/chats").hasAnyRole(OWNER, MASTER));
+                        .requestMatchers(HttpMethod.POST, "/api/chats").hasAnyAuthority(OWNER, MASTER));
 
         http.sessionManagement(
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));


### PR DESCRIPTION
`WebSecurityConfig` 에서 엔드포인트별 접근 권한을 `hasRole` 대신 `hasAuthority`를 사용하도록 고쳤습니다.

왜 hasRole이 동작하지 않았냐면..

hasRole은 Role 이름앞에 `ROLE_`이 붙어야 검증해야 할 역할을 알아봅니다.

하지만 제가 구현한 UserRoleEnum은 `ROLE_`이 붙지 않고,
https://github.com/daeundada/jeogiyo_sparta19/blob/5cedc2eb371b9caad1333055c9d6df6fe3b4a5cd/src/main/java/sparta/jeogiyo/domain/user/entity/UserRoleEnum.java#L5-L16

아래 UserDetailsImpl에서 이 값을 바로 `SimpleGrantedAuthority`로 만들고 있었기 때문이죠..

https://github.com/daeundada/jeogiyo_sparta19/blob/5cedc2eb371b9caad1333055c9d6df6fe3b4a5cd/src/main/java/sparta/jeogiyo/domain/user/UserDetailsImpl.java#L19-L23

hasAnyRole('ADMIN')을 예로 들면 이 메서드는 내부적으로 ROLE_을 접두사로 붙여 `ROLE_ADMIN`을 찾으려하나, 이미 ROLE_이 붙어있지 않은 상태로 들어가버려서 권한을 찾지 못한 것 이었습니다.

hasAuthority는 문자열 그대로 찾기 때문에 이를 사용하는 것이 더 적합합니다.