### PR TITLE
feat: 장바구니 API 구현 

### DIFF
--- a/src/main/java/sparta/jeogiyo/domain/cart/controller/CartController.java
+++ b/src/main/java/sparta/jeogiyo/domain/cart/controller/CartController.java
@@ -1,0 +1,64 @@
+package sparta.jeogiyo.domain.cart.controller;
+
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sparta.jeogiyo.domain.cart.dto.request.CartCreateRequestDto;
+import sparta.jeogiyo.domain.cart.dto.request.CartUpdateRequestDto;
+import sparta.jeogiyo.domain.cart.dto.response.CartResponseDto;
+import sparta.jeogiyo.domain.cart.service.CartService;
+import sparta.jeogiyo.domain.user.UserDetailsImpl;
+import sparta.jeogiyo.global.response.ApiResponse;
+
+@RestController
+@RequestMapping("/api/carts")
+public class CartController {
+
+    private final CartService cartService;
+
+    public CartController(CartService cartService) {
+        this.cartService = cartService;
+    }
+
+    @PostMapping("/products")
+    public ResponseEntity<Object> addCart(@RequestBody CartCreateRequestDto requestDto) {
+        CartResponseDto cartResponseDto = cartService.addCart(requestDto);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.of("장바구니에 성공적으로 담겼습니다.", cartResponseDto));
+    }
+
+    @PutMapping("/products")
+    public ResponseEntity<Object> updateCart(@RequestBody CartUpdateRequestDto requestDto) {
+        CartResponseDto cartResponseDto = cartService.updateCart(requestDto);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.of("수정되었습니다.", cartResponseDto));
+    }
+
+    @DeleteMapping("/products/{productId}")
+    public ResponseEntity<Void> deleteProductFromCart(@PathVariable UUID productId) {
+        cartService.deleteProductFromCart(productId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/products")
+    public ResponseEntity<Void> deleteAllProductsFromCart(@AuthenticationPrincipal UserDetailsImpl user) {
+        cartService.deleteAllProductsFromCart(user);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<Object> getUserCarts(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        CartResponseDto cart = cartService.getUserCarts(userDetails.getUser());
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.of("장바구니 목록", cart));
+    }
+
+}

--- a/src/main/java/sparta/jeogiyo/domain/cart/dto/request/CartCreateRequestDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/cart/dto/request/CartCreateRequestDto.java
@@ -1,0 +1,22 @@
+package sparta.jeogiyo.domain.cart.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class CartCreateRequestDto {
+
+    @NotEmpty
+    private UUID storeId;
+
+    @NotEmpty
+    private UUID productId;
+
+    @NotNull
+    @Size(min = 1, max = 99)
+    private int quantity;
+
+}

--- a/src/main/java/sparta/jeogiyo/domain/cart/dto/request/CartUpdateRequestDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/cart/dto/request/CartUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package sparta.jeogiyo.domain.cart.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class CartUpdateRequestDto {
+
+    @NotEmpty
+    private UUID productId;
+
+    @NotNull
+    @Size(min = 1, max = 99)
+    private Integer quantity;
+
+}

--- a/src/main/java/sparta/jeogiyo/domain/cart/dto/response/CartProductResponseDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/cart/dto/response/CartProductResponseDto.java
@@ -1,0 +1,42 @@
+package sparta.jeogiyo.domain.cart.dto.response;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import sparta.jeogiyo.domain.cart.entity.Cart;
+import sparta.jeogiyo.domain.product.entity.Product;
+import sparta.jeogiyo.domain.store.domain.Store;
+
+@Getter
+@Builder
+public class CartProductResponseDto {
+
+    private UUID cartId;
+
+    private UUID storeId;
+
+    private String storeName;
+
+    private UUID productId;
+
+    private String productName;
+
+    private Integer productPrice;
+
+    private Integer quantity;
+
+    public static CartProductResponseDto fromEntity(Cart cart,
+            Integer quantity) {
+        Product product = cart.getProduct();
+        Store store = cart.getStore();
+        return CartProductResponseDto.builder()
+                .cartId(cart.getCartId())
+                .storeId(store.getStoreId())
+                .storeName(store.getStoreName())
+                .productId(product.getProductId())
+                .productName(product.getProductName())
+                .productPrice(product.getProductPrice())
+                .quantity(quantity)
+                .build();
+    }
+}

--- a/src/main/java/sparta/jeogiyo/domain/cart/dto/response/CartResponseDto.java
+++ b/src/main/java/sparta/jeogiyo/domain/cart/dto/response/CartResponseDto.java
@@ -1,0 +1,30 @@
+package sparta.jeogiyo.domain.cart.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import sparta.jeogiyo.domain.user.entity.User;
+
+@Getter
+@Builder
+public class CartResponseDto {
+
+    private Long userId;
+
+    private List<CartProductResponseDto> products;
+
+    private Integer cartTotalPrice;
+
+    private Integer totalQuantity;
+
+    public static CartResponseDto fromEntity(User user,
+            List<CartProductResponseDto> productResponseDtoList, int cartTotalPrice, int totalQuantity) {
+
+        return CartResponseDto.builder()
+                .userId(user.getUserId())
+                .cartTotalPrice(cartTotalPrice)
+                .totalQuantity(totalQuantity)
+                .products(productResponseDtoList)
+                .build();
+    }
+}

--- a/src/main/java/sparta/jeogiyo/domain/cart/entity/Cart.java
+++ b/src/main/java/sparta/jeogiyo/domain/cart/entity/Cart.java
@@ -1,0 +1,66 @@
+package sparta.jeogiyo.domain.cart.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sparta.jeogiyo.domain.product.entity.Product;
+import sparta.jeogiyo.domain.store.domain.Store;
+import sparta.jeogiyo.domain.user.entity.User;
+import sparta.jeogiyo.global.entity.BaseTimeEntity;
+
+@Table(name = "p_carts")
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cart extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "cart_id", nullable = false, columnDefinition = "UUID")
+    private UUID cartId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    private Integer cartTotalPrice;
+
+    private Integer quantity;
+
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    public void update(int quantity) {
+        this.quantity = quantity;
+        this.cartTotalPrice = product.getProductPrice() * quantity;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+        this.setDeletedAt(LocalDateTime.now());
+        this.setDeletedBy(this.user.getUsername());
+    }
+
+}

--- a/src/main/java/sparta/jeogiyo/domain/cart/repository/CartRepository.java
+++ b/src/main/java/sparta/jeogiyo/domain/cart/repository/CartRepository.java
@@ -1,0 +1,24 @@
+package sparta.jeogiyo.domain.cart.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import sparta.jeogiyo.domain.cart.entity.Cart;
+
+@Repository
+public interface CartRepository extends JpaRepository<Cart, UUID> {
+
+    @EntityGraph(attributePaths = {"user", "product", "store"})
+    @Query("SELECT c FROM Cart c WHERE c.user.userId = :userId AND c.user.isDeleted = false")
+    List<Cart> findCartsByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT c FROM Cart c JOIN c.product p JOIN c.store s WHERE c.product.productId = :productId AND c.user.userId = :userId AND c.isDeleted = false")
+    Optional<Cart> findCartByProductIdAndUserID(@Param("productId") UUID productId,
+            @Param("userId") Long userId);
+
+}

--- a/src/main/java/sparta/jeogiyo/domain/cart/service/CartService.java
+++ b/src/main/java/sparta/jeogiyo/domain/cart/service/CartService.java
@@ -1,0 +1,164 @@
+package sparta.jeogiyo.domain.cart.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.jeogiyo.domain.cart.dto.request.CartCreateRequestDto;
+import sparta.jeogiyo.domain.cart.dto.request.CartUpdateRequestDto;
+import sparta.jeogiyo.domain.cart.dto.response.CartProductResponseDto;
+import sparta.jeogiyo.domain.cart.dto.response.CartResponseDto;
+import sparta.jeogiyo.domain.cart.entity.Cart;
+import sparta.jeogiyo.domain.cart.repository.CartRepository;
+import sparta.jeogiyo.domain.product.entity.Product;
+import sparta.jeogiyo.domain.product.repository.ProductRepository;
+import sparta.jeogiyo.domain.store.domain.Store;
+import sparta.jeogiyo.domain.store.repository.StoreRepository;
+import sparta.jeogiyo.domain.user.UserDetailsImpl;
+import sparta.jeogiyo.domain.user.entity.User;
+import sparta.jeogiyo.global.response.CustomException;
+import sparta.jeogiyo.global.response.ErrorCode;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final ProductRepository productRepository;
+    private final StoreRepository storeRepository;
+
+    @Transactional(readOnly = true)
+    public CartResponseDto getUserCarts(User user) {
+        log.info("User ID: {}의 장바구니를 조회합니다.", user.getUserId());
+        List<Cart> cartList = cartRepository.findCartsByUserId(user.getUserId());
+        if (cartList.isEmpty()) {
+            log.warn("User ID: {}의 장바구니가 비어 있습니다.", user.getUserId());
+            throw new CustomException(ErrorCode.CART_IS_EMPTY);
+        }
+
+        List<CartProductResponseDto> productResponseDtoList = new ArrayList<>();
+        int totalPrice = 0;
+        int totalQuantity = 0;
+
+        for (Cart cart : cartList) {
+            totalQuantity += cart.getQuantity();
+            totalPrice += cart.getCartTotalPrice();
+            productResponseDtoList.add(CartProductResponseDto.fromEntity(cart, cart.getQuantity()));
+        }
+
+        log.info("사용자 ID: {}의 장바구니를 반환합니다. 총 가격: {}, 총 수량: {}",
+                user.getUserId(), totalPrice, totalQuantity);
+        return CartResponseDto.fromEntity(user, productResponseDtoList, totalPrice, totalQuantity);
+    }
+
+    @Transactional
+    public CartResponseDto addCart(CartCreateRequestDto requestDto) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) SecurityContextHolder.getContext()
+                .getAuthentication().getPrincipal();
+        User user = userDetails.getUser();
+        log.info("User ID: {}의 장바구니에 제품 ID: {}를 추가합니다.", user.getUserId(),
+                requestDto.getProductId());
+
+        Product product = productRepository.findById(requestDto.getProductId())
+                .orElseThrow(() -> {
+                    log.error("Product ID: {}를 찾을 수 없습니다.", requestDto.getProductId());
+                    return new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+                });
+
+        if (cartRepository.findCartByProductIdAndUserID(product.getProductId(), user.getUserId())
+                .isPresent()) {
+            log.warn("User ID: {}의 장바구니에 제품 ID: {}가 이미 존재합니다.", user.getUserId(),
+                    product.getProductId());
+            throw new CustomException(ErrorCode.CART_PRODUCT_ALREADY_EXIST);
+        }
+
+        Store store = storeRepository.findById(product.getStore().getStoreId())
+                .orElseThrow(() -> {
+                    log.error("Store ID: {}를 찾을 수 없습니다.", product.getStore().getStoreId());
+                    return new CustomException(ErrorCode.STORE_ID_NOT_FOUND);
+                });
+
+        int quantity = requestDto.getQuantity();
+        int cartPrice = product.getProductPrice() * quantity;
+
+        Cart cart = Cart.builder()
+                .user(user)
+                .store(store)
+                .product(product)
+                .cartTotalPrice(cartPrice)
+                .quantity(quantity)
+                .build();
+
+        cartRepository.save(cart);
+        log.info("User ID: {}의 장바구니에 Product ID: {}가 추가되었습니다.", user.getUserId(),
+                product.getProductId());
+
+        return getUserCarts(user);
+    }
+
+    @Transactional
+    public CartResponseDto updateCart(CartUpdateRequestDto requestDto) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) SecurityContextHolder.getContext()
+                .getAuthentication().getPrincipal();
+        User user = userDetails.getUser();
+        log.info("User ID: {}의 장바구니에서 Product ID: {}를 업데이트합니다.", user.getUserId(),
+                requestDto.getProductId());
+
+        Cart cart = cartRepository.findCartByProductIdAndUserID(requestDto.getProductId(),
+                        user.getUserId())
+                .orElseThrow(() -> {
+                    log.warn("User ID: {}의 장바구니가 비어 있습니다.", user.getUserId());
+                    return new CustomException(ErrorCode.CART_IS_EMPTY);
+                });
+
+        cart.update(requestDto.getQuantity());
+        cartRepository.save(cart);
+        log.info("User ID: {}의 장바구니에서 Product ID: {}가 업데이트되었습니다.", user.getUserId(),
+                requestDto.getProductId());
+
+        return getUserCarts(user);
+    }
+
+    @Transactional
+    public void deleteAllProductsFromCart(UserDetailsImpl userDetails) {
+        User user = userDetails.getUser();
+        log.info("User ID: {}의 장바구니에서 모든 제품을 삭제합니다.", user.getUserId());
+
+        List<Cart> cartList = cartRepository.findCartsByUserId(user.getUserId());
+        if (cartList.isEmpty()) {
+            log.warn("User ID: {}의 장바구니에 삭제할 제품이 없습니다.", user.getUserId());
+            throw new CustomException(ErrorCode.CART_IS_EMPTY);
+        }
+        List<Cart> deletedCart = new ArrayList<>();
+        for (Cart cart : cartList) {
+            cart.delete();
+            deletedCart.add(cart);
+        }
+
+        cartRepository.saveAll(deletedCart);
+        log.info("User ID: {}의 장바구니에서 모든 Product가 삭제되었습니다.", user.getUserId());
+    }
+
+    @Transactional
+    public void deleteProductFromCart(UUID productId) {
+        UserDetailsImpl userDetails = (UserDetailsImpl) SecurityContextHolder.getContext()
+                .getAuthentication().getPrincipal();
+        User user = userDetails.getUser();
+        log.info("User ID: {}의 장바구니에서 Product ID: {}를 삭제합니다.", user.getUserId(), productId);
+
+        Cart cart = cartRepository.findCartByProductIdAndUserID(productId, user.getUserId())
+                .orElseThrow(() -> {
+                    log.warn("User ID: {}의 장바구니가 비어 있거나, Product ID: {}를 찾을 수 없습니다.",
+                            user.getUserId(), productId);
+                    return new CustomException(ErrorCode.CART_IS_EMPTY);
+                });
+
+        cart.delete();
+        log.info("User ID: {}의 장바구니에서 Product ID: {}가 삭제되었습니다.", user.getUserId(), productId);
+    }
+}

--- a/src/main/java/sparta/jeogiyo/domain/product/dto/response/ProductResponse.java
+++ b/src/main/java/sparta/jeogiyo/domain/product/dto/response/ProductResponse.java
@@ -3,9 +3,11 @@ package sparta.jeogiyo.domain.product.dto.response;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 @AllArgsConstructor
 @Builder
+@Getter
 public class ProductResponse {
 
     private UUID productId;

--- a/src/main/java/sparta/jeogiyo/domain/product/entity/Product.java
+++ b/src/main/java/sparta/jeogiyo/domain/product/entity/Product.java
@@ -46,10 +46,10 @@ public class Product extends BaseTimeEntity {
     private String productExplain;
 
     @Column(name = "is_deleted", nullable = false)
-    private boolean Is_deleted = false;
+    private Boolean isDeleted = false;
 
     public void delete(UserDetailsImpl user) {
-        this.Is_deleted = true;
+        this.isDeleted = true;
         this.setDeletedAt(LocalDateTime.now());
         this.setDeletedBy(user.getUser().getUsername());
     }

--- a/src/main/java/sparta/jeogiyo/domain/user/entity/User.java
+++ b/src/main/java/sparta/jeogiyo/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sparta.jeogiyo.domain.cart.entity.Cart;
 import sparta.jeogiyo.domain.user.dto.request.UserUpdateRequestDto;
 import sparta.jeogiyo.global.entity.BaseTimeEntity;
 
@@ -32,6 +34,9 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "user_id")
     private Long userId;
+
+    @OneToMany(mappedBy = "user", orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Cart> carts;
 
     @Column(nullable = false, unique = true)
     private String username;

--- a/src/main/java/sparta/jeogiyo/global/security/WebSecurityConfig.java
+++ b/src/main/java/sparta/jeogiyo/global/security/WebSecurityConfig.java
@@ -118,10 +118,10 @@ public class WebSecurityConfig {
 
                         // 상품 관련
                         // 상품 생성
-                        .requestMatchers(HttpMethod.POST, "/api/products/store/**").hasAuthority(OWNER)
+                        .requestMatchers(HttpMethod.POST, "/api/products").hasAuthority(OWNER)
 
                         // 상품 수정
-                        .requestMatchers(HttpMethod.PATCH, "/api/products/**").hasAuthority(OWNER)
+                        .requestMatchers(HttpMethod.PUT, "/api/products/**").hasAuthority(OWNER)
 
                         // 상품 삭제
                         .requestMatchers(HttpMethod.DELETE, "/api/products/**")
@@ -135,11 +135,19 @@ public class WebSecurityConfig {
 
                         // 장바구니 관련
                         // 장바구니 메뉴 담기
-                        .requestMatchers(HttpMethod.POST, "/api/carts/product/**")
+                        .requestMatchers(HttpMethod.POST, "/api/carts/products")
+                        .hasAnyAuthority(CUSTOMER, MASTER)
+
+                        // 장바구니 수량 수정
+                        .requestMatchers(HttpMethod.PUT, "/api/carts/products")
+                        .hasAnyAuthority(CUSTOMER, MASTER)
+
+                        // 장바구니 메뉴 전체 삭제
+                        .requestMatchers(HttpMethod.DELETE, "/api/carts/products")
                         .hasAnyAuthority(CUSTOMER, MASTER)
 
                         // 장바구니 메뉴 삭제
-                        .requestMatchers(HttpMethod.DELETE, "/api/carts/product/**")
+                        .requestMatchers(HttpMethod.DELETE, "/api/carts/products/**")
                         .hasAnyAuthority(CUSTOMER, MASTER)
 
                         // 장바구니 조회


### PR DESCRIPTION
장바구니 관련 API를 구현하였습니다.

### 주요 내용
- 장바구니는 사용자가 하나의 상품을 추가할 때마다 생성을 요청한다는 시나리오로 구현했습니다.
- 장바구니 수정은 그 상품의 대한 수량만 수정하도록 구현하였습니다.
- 장바구니 품목은 그 품목만, 또는 전체 삭제가 구현되어 있습니다.

### 장바구니 조회
아래와 같이 응답이 돌아옵니다.
```json
{
    "userId": 1,
    "products": [
        {
            "cartId": "8dc610ee-30ca-4a02-aaf4-37bcdf1353ba",
            "storeId": "45a62637-6fe9-4201-826a-9062b30e8d52",
            "storeName": "라면 가게",
            "productId": "45a62637-6fe9-4201-826a-9062b30e8d51",
            "productName": "진라면",
            "productPrice": 100,
            "quantity": 4
        },
        {
            "cartId": "8097058c-ace3-49a4-8c20-df42ee1526c7",
            "storeId": "45a62637-6fe9-4201-826a-9062b30e8d52",
            "storeName": "라면 가게",
            "productId": "45a62637-6fe9-4201-826a-9062b30e8d50",
            "productName": "신라면",
            "productPrice": 500,
            "quantity": 2
        }
    ],
    "cartTotalPrice": 1400,
    "totalQuantity": 6
}
```
