### PR TITLE
feature: chat 질문, 답변 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     //jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/sparta/jeogiyo/domain/chat/controller/ChatController.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/controller/ChatController.java
@@ -1,5 +1,6 @@
 package sparta.jeogiyo.domain.chat.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,11 +21,11 @@ public class ChatController {
     private final ChatService chatService;
 
     @PostMapping("/api/chats")
-    public ResponseEntity<ApiResponse<ChatResponseDTO>> CreateChat(
-            @RequestBody ChatRequestDTO requestDTO,
+    public ResponseEntity<ApiResponse<ChatResponseDTO>> createChat(
+            @RequestBody @Valid ChatRequestDTO requestDTO,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        ChatResponseDTO responseDTO = chatService.CreateChat(requestDTO, userDetails);
+        ChatResponseDTO responseDTO = chatService.createChat(requestDTO, userDetails);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/src/main/java/sparta/jeogiyo/domain/chat/controller/ChatController.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/controller/ChatController.java
@@ -1,0 +1,35 @@
+package sparta.jeogiyo.domain.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import sparta.jeogiyo.domain.chat.dto.request.ChatRequestDTO;
+import sparta.jeogiyo.domain.chat.dto.response.ChatResponseDTO;
+import sparta.jeogiyo.domain.chat.service.ChatService;
+import sparta.jeogiyo.domain.user.UserDetailsImpl;
+import sparta.jeogiyo.global.response.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @PostMapping("/api/chats")
+    public ResponseEntity<ApiResponse<ChatResponseDTO>> CreateChat(
+            @RequestBody ChatRequestDTO requestDTO,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        ChatResponseDTO responseDTO = chatService.CreateChat(requestDTO, userDetails);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.of("채팅 성공", responseDTO));
+
+    }
+
+}

--- a/src/main/java/sparta/jeogiyo/domain/chat/dto/request/ChatRequestDTO.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/dto/request/ChatRequestDTO.java
@@ -1,5 +1,7 @@
 package sparta.jeogiyo.domain.chat.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 public class ChatRequestDTO {
@@ -15,6 +17,8 @@ public class ChatRequestDTO {
         public static class Parts {
 
             @Getter
+            @NotBlank
+            @Size(max = 100)
             private String text;
         }
     }

--- a/src/main/java/sparta/jeogiyo/domain/chat/dto/request/ChatRequestDTO.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/dto/request/ChatRequestDTO.java
@@ -1,0 +1,21 @@
+package sparta.jeogiyo.domain.chat.dto.request;
+
+import lombok.Getter;
+
+public class ChatRequestDTO {
+
+    @Getter
+    private Contents contents;
+
+    public static class Contents {
+
+        @Getter
+        private Parts parts;
+
+        public static class Parts {
+
+            @Getter
+            private String text;
+        }
+    }
+}

--- a/src/main/java/sparta/jeogiyo/domain/chat/dto/response/ChatResponseDTO.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/dto/response/ChatResponseDTO.java
@@ -1,0 +1,11 @@
+package sparta.jeogiyo.domain.chat.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class ChatResponseDTO {
+
+    @Setter
+    private String answer;
+}

--- a/src/main/java/sparta/jeogiyo/domain/chat/dto/response/ChatResponseDTO.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/dto/response/ChatResponseDTO.java
@@ -8,4 +8,8 @@ public class ChatResponseDTO {
 
     @Setter
     private String answer;
+
+    public ChatResponseDTO(String answer) {
+        this.answer = answer;
+    }
 }

--- a/src/main/java/sparta/jeogiyo/domain/chat/entity/Chat.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/entity/Chat.java
@@ -16,7 +16,6 @@ public class Chat extends BaseTimeEntity {
 
     @Id
     @UuidGenerator
-    @GeneratedValue
     @Column(name = "chat_id", updatable = false, nullable = false) // 컬럼 설정
     private UUID chatId;
 

--- a/src/main/java/sparta/jeogiyo/domain/chat/entity/Chat.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/entity/Chat.java
@@ -1,0 +1,38 @@
+package sparta.jeogiyo.domain.chat.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+import sparta.jeogiyo.domain.user.entity.User;
+import sparta.jeogiyo.global.entity.BaseTimeEntity;
+
+import java.util.UUID;
+
+@Table(name = "p_chats")
+@Getter
+@Entity
+public class Chat extends BaseTimeEntity {
+
+    @Id
+    @UuidGenerator
+    @GeneratedValue
+    @Column(name = "chat_id", updatable = false, nullable = false) // 컬럼 설정
+    private UUID chatId;
+
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Setter
+    @Column(length = 100)
+    private String question;
+
+    @Setter
+    @Column(length = 1000)
+    private String answer;
+
+    @Setter
+    private Boolean isDeleted = false;
+}

--- a/src/main/java/sparta/jeogiyo/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/repository/ChatRepository.java
@@ -1,0 +1,7 @@
+package sparta.jeogiyo.domain.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sparta.jeogiyo.domain.chat.entity.Chat;
+
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+}

--- a/src/main/java/sparta/jeogiyo/domain/chat/service/ChatService.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/service/ChatService.java
@@ -2,6 +2,7 @@ package sparta.jeogiyo.domain.chat.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import sparta.jeogiyo.domain.chat.entity.Chat;
 import sparta.jeogiyo.domain.chat.repository.ChatRepository;
 import sparta.jeogiyo.domain.user.UserDetailsImpl;
 
+@Slf4j
 @Service
 public class ChatService {
 
@@ -34,7 +36,7 @@ public class ChatService {
     }
 
     @Transactional
-    public ChatResponseDTO CreateChat(ChatRequestDTO chatRequestDTO, UserDetailsImpl userDetails) {
+    public ChatResponseDTO createChat(ChatRequestDTO chatRequestDTO, UserDetailsImpl userDetails) {
 
 
         String apiResponse = getAnswer(chatRequestDTO);
@@ -68,12 +70,15 @@ public class ChatService {
             return response.block();
 
         } catch (WebClientResponseException e) {
-            System.err.println(
-                    "Error response: " + e.getStatusCode() + " - " + e.getResponseBodyAsString());
-            return null;
+
+            log.error("응답 오류, 상태 코드: {}, 응답 본문: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new RuntimeException("서버로부터 답변을 가져오는 데 실패했습니다: " + e.getMessage(), e);
+
         } catch (Exception e) {
-            e.printStackTrace();
-            return null;
+
+            log.error("서버로 답변 요청 중 예상치 못한 오류가 발생했습니다.", e);
+            throw new RuntimeException("예상치 못한 오류가 발생했습니다: " + e.getMessage(), e);
+
         }
     }
 

--- a/src/main/java/sparta/jeogiyo/domain/chat/service/ChatService.java
+++ b/src/main/java/sparta/jeogiyo/domain/chat/service/ChatService.java
@@ -1,0 +1,97 @@
+package sparta.jeogiyo.domain.chat.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient.Builder;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import sparta.jeogiyo.domain.chat.dto.request.ChatRequestDTO;
+import sparta.jeogiyo.domain.chat.dto.response.ChatResponseDTO;
+import sparta.jeogiyo.domain.chat.entity.Chat;
+import sparta.jeogiyo.domain.chat.repository.ChatRepository;
+import sparta.jeogiyo.domain.user.UserDetailsImpl;
+
+@Service
+public class ChatService {
+
+    private final ChatRepository chatRepository;
+    private final WebClient webClient;
+    @Value("${api.key}")
+    private String apiKey;
+
+
+    @Autowired
+    public ChatService(ChatRepository chatRepository, Builder webClientBuilder) {
+        this.chatRepository = chatRepository;
+        this.webClient = webClientBuilder.baseUrl(
+                        "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent")
+                .build();
+    }
+
+    @Transactional
+    public ChatResponseDTO CreateChat(ChatRequestDTO chatRequestDTO, UserDetailsImpl userDetails) {
+
+
+        String apiResponse = getAnswer(chatRequestDTO);
+
+        ChatResponseDTO apiAnswer = parseResponse(apiResponse);
+
+        Chat chat = new Chat();
+
+        chat.setUser(userDetails.getUser());
+        chat.setAnswer(apiAnswer.getAnswer());
+        chat.setQuestion(chatRequestDTO.getContents().getParts().getText());
+
+        chatRepository.save(chat);
+
+        return apiAnswer;
+    }
+
+    public String getAnswer(ChatRequestDTO chatRequestDTO) {
+
+        String requestBody = String.format("{\"contents\":[{\"parts\":[{\"text\":\"%s 100자 안으로 대답해줘\"}]}]}",
+                chatRequestDTO.getContents().getParts().getText());
+
+        try {
+            Mono<String> response = webClient.post().uri(
+                            uriBuilder -> uriBuilder.queryParam("key", apiKey).build())
+                    .header("Content-Type", "application/json")
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(String.class);
+
+            return response.block();
+
+        } catch (WebClientResponseException e) {
+            System.err.println(
+                    "Error response: " + e.getStatusCode() + " - " + e.getResponseBodyAsString());
+            return null;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private ChatResponseDTO parseResponse(String jsonResponse) {
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode rootNode = objectMapper.readTree(jsonResponse);
+
+            JsonNode textNode = rootNode.path("candidates").get(0)
+                    .path("content").path("parts").get(0).path("text");
+
+            return new ChatResponseDTO(textNode.asText());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,5 +15,8 @@ spring:
 
 jwt:
   secret:
-    expiration-time: 60 * 60 * 1000L
+    expiration-time: 3600000
     key: ${LOCAL_JWT_SECRET_KEY}
+
+api:
+  key: ${YOUR_API_KEY}


### PR DESCRIPTION
채팅 관련 api를 구현했습니다.

### 주요 내용
- 질문하면 ai 답변이 응답 됩니다.
- 질문, 답변 모두 DB에 저장됩니다.
- 채팅방은 들어갈때마다 새로 리셋된다는 조건하에 개발이 진행되어서 조회 기능은 따로 구현하지 않았습니다.

### 요청 Json

```
{
  "contents": {
    "parts": {
      "text": "짜장면 이름 추천해줘"
    }
  }
}
```

### 응답 Json
```
{
    "message": "채팅 성공",
    "data": {
        "answer": "## 짜장면 이름 추천 (100자 안)\n\n* 
**고전:** 짜장면, 검은 면, 흑룡면, 춘장면\n* **세련:** 블랙 라멘, 챠이니즈 누들, 면요리 마스터, 검은 벨벳\n* 
**유쾌:** 짜장 폭탄, 면사냥, 꿀맛 면, 짜장 마법사\n* 
**특색:** 해물 짜장, 짜장 볶음밥, 짜장 떡볶이, 짜장 샐러드 \n\n
어떤 분위기의 짜장면인지에 따라 선택해보세요! 🍜 \n"
    }
}
```